### PR TITLE
fix: DomainEventPublisher Bean 생성 오류 수정 (#14)

### DIFF
--- a/bootstrap/customer-api/src/main/java/com/commerce/customer/api/CustomerApiApplication.java
+++ b/bootstrap/customer-api/src/main/java/com/commerce/customer/api/CustomerApiApplication.java
@@ -7,7 +7,8 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 @SpringBootApplication(scanBasePackages = {
     "com.commerce.customer.core",
     "com.commerce.customer.api",
-    "com.commerce.infrastructure.persistence"
+    "com.commerce.infrastructure.persistence",
+    "com.commerce.infrastructure.kafka"
 })
 @EnableDiscoveryClient
 public class CustomerApiApplication {


### PR DESCRIPTION
## Summary
- CustomerApiApplication의 @SpringBootApplication 스캔 패키지에 kafka 모듈 추가
- com.commerce.infrastructure.kafka 패키지를 스캔하여 DomainEventPublisherAdapter Bean이 생성되도록 수정

## 문제 해결
어플리케이션 실행 시 발생하던 아래 오류를 해결했습니다:
```
Parameter 4 of constructor in com.commerce.customer.core.application.service.AccountApplicationService required a bean of type 'com.commerce.customer.core.domain.event.DomainEventPublisher' that could not be found.
```

## 변경사항
- `CustomerApiApplication.java`: @SpringBootApplication의 scanBasePackages에 "com.commerce.infrastructure.kafka" 추가

## Test plan
- [x] 프로젝트 빌드 성공 확인 (`./gradlew clean build -x test`)
- [ ] 애플리케이션 실행 시 Bean 오류가 발생하지 않음을 확인

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)