### PR TITLE
feat: Eureka 클라이언트 제거 (#22)

### DIFF
--- a/bootstrap/customer-api/build.gradle
+++ b/bootstrap/customer-api/build.gradle
@@ -37,8 +37,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
     
-    // Spring Cloud
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     
     // API 문서화
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/bootstrap/customer-api/src/main/java/com/commerce/customer/api/CustomerApiApplication.java
+++ b/bootstrap/customer-api/src/main/java/com/commerce/customer/api/CustomerApiApplication.java
@@ -2,7 +2,6 @@ package com.commerce.customer.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication(scanBasePackages = {
     "com.commerce.customer.core",
@@ -10,7 +9,6 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
     "com.commerce.infrastructure.persistence",
     "com.commerce.infrastructure.kafka"
 })
-@EnableDiscoveryClient
 public class CustomerApiApplication {
     public static void main(String[] args) {
         SpringApplication.run(CustomerApiApplication.class, args);

--- a/bootstrap/customer-api/src/main/resources/application.yml
+++ b/bootstrap/customer-api/src/main/resources/application.yml
@@ -7,13 +7,6 @@ spring:
 server:
   port: 8080
 
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/eureka/
-  instance:
-    prefer-ip-address: true
-
 management:
   endpoints:
     web:

--- a/bootstrap/customer-api/src/test/java/com/commerce/customer/api/integration/AbstractIntegrationTest.java
+++ b/bootstrap/customer-api/src/test/java/com/commerce/customer/api/integration/AbstractIntegrationTest.java
@@ -105,8 +105,7 @@ public abstract class AbstractIntegrationTest {
         // 이벤트 발행 비활성화
         registry.add("spring.application.events.enabled", () -> "false");
         
-        // Eureka 비활성화
-        registry.add("eureka.client.enabled", () -> "false");
+        // Cloud Discovery 비활성화
         registry.add("spring.cloud.discovery.enabled", () -> "false");
     }
 

--- a/bootstrap/customer-api/src/test/resources/application-integration.yml
+++ b/bootstrap/customer-api/src/test/resources/application-integration.yml
@@ -40,12 +40,6 @@ spring:
       secret: test-secret-key-for-integration-test-that-is-long-enough
       expiration: 3600000
       refresh-expiration: 86400000
-    
-eureka:
-  client:
-    enabled: false
-    register-with-eureka: false
-    fetch-registry: false
 
 logging:
   level:

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,6 @@ configure(subprojects.findAll { it.path.startsWith(':bootstrap:') }) {
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-security'
-        implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.springframework.security:spring-security-test'


### PR DESCRIPTION
## Summary
- Spring Cloud Eureka Client 의존성과 관련 설정을 제거했습니다.
- 아직 Eureka 서버가 구축되지 않아서 불필요한 의존성을 제거하는 작업입니다.

## 변경사항
- ✅ 루트 및 customer-api `build.gradle`에서 `spring-cloud-starter-netflix-eureka-client` 의존성 제거
- ✅ `application.yml`과 `application-integration.yml`에서 Eureka 관련 설정 제거
- ✅ `CustomerApiApplication.java`에서 `@EnableDiscoveryClient` 애노테이션 제거
- ✅ `AbstractIntegrationTest.java`에서 Eureka 비활성화 설정 제거

## 테스트 결과
- 전체 빌드 및 테스트 통과 완료
- `./gradlew clean build` 성공

## 관련 이슈
- Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)