### PR TITLE
feat: GitHub Container Registry 배포 액션 개발

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -1,0 +1,94 @@
+name: Deploy to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # main 브랜치로 머지될 때만 실행
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
+      - name: Run tests
+        run: ./gradlew test
+        
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix={{branch}}-
+            
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          
+      - name: Generate image report
+        run: |
+          echo "## Docker Image Published! 🎉" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** ${{ env.REGISTRY }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull command:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 개요
main 브랜치로 병합될 때 GitHub Container Registry(ghcr.io)에 Docker 이미지를 자동으로 빌드하고 푸시하는 GitHub Actions 워크플로우를 추가했습니다.

## 구현 내용

### 워크플로우 트리거
- main 브랜치로의 직접 push
- main 브랜치로의 PR 머지

### 주요 기능
1. **자동화된 빌드 프로세스**
   - JDK 17 환경 설정
   - Gradle을 통한 테스트 실행
   - 테스트 통과 후 Docker 이미지 빌드

2. **GitHub Container Registry 통합**
   - ghcr.io 레지스트리 사용
   - GitHub 토큰을 통한 자동 인증
   - 저장소 이름과 동일한 이미지 이름 사용

3. **멀티 플랫폼 지원**
   - linux/amd64
   - linux/arm64

4. **스마트 태깅 전략**
   - `latest`: main 브랜치의 최신 버전
   - `main-<SHA>`: 커밋 SHA 기반 태그
   - 브랜치명 기반 태그
   - Semantic versioning 지원 (태그 사용 시)

5. **빌드 최적화**
   - Docker Buildx를 통한 효율적인 빌드
   - GitHub Actions 캐시를 활용한 빌드 속도 개선

6. **빌드 리포트**
   - 빌드 완료 후 상세 정보 제공
   - 이미지 pull 명령어 포함

## 사용 방법

워크플로우는 main 브랜치로 코드가 머지될 때 자동으로 실행됩니다.

빌드된 이미지는 다음 명령어로 pull 할 수 있습니다:
```bash
docker pull ghcr.io/wlgns5376/msa-ecommerce-customer:latest
```

## 테스트
- GitHub Actions 워크플로우 문법 검증 완료
- 모든 필수 권한(contents: read, packages: write) 설정 완료

Closes #45